### PR TITLE
Increase default timeout of playwright and add time to log statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const MAX_32_BIT_SIGNED_INTEGER = Math.pow(2, 31) - 1
 
   const browser = await chromium.launch({ headless: false })
   const page = await browser.newPage()
+  page.setDefaultTimeout(90000)
   await page.goto(
     'https://sachsen.impfterminvergabe.de/civ.public/start.html?oe=00.00.IM&mode=cc&cc_key=IOAktion'
   )

--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ const MAX_32_BIT_SIGNED_INTEGER = Math.pow(2, 31) - 1
         })
         return
       }
-      console.log(`No success for ${currentCentre}`)
+      console.log(
+        `No success for ${currentCentre} (${new Date().toLocaleTimeString()})`
+      )
       await page.click('button:has(span:is(:text("Zurück")))')
     }
 


### PR DESCRIPTION
This prevents the program from crashing when page takes longer to load because of high traffic